### PR TITLE
Adds boilerplate code for metadata extraction

### DIFF
--- a/M-SAVA-BLL/Utils/FileUtils.cs
+++ b/M-SAVA-BLL/Utils/FileUtils.cs
@@ -300,7 +300,7 @@ namespace M_SAVA_BLL.Utils
             IQueryable<string> tags = (dto.Tags ?? new List<string>()).AsQueryable();
             IQueryable<string> categories = (dto.Categories ?? new List<string>()).AsQueryable();
 
-            JsonDocument metadata = MetadataUtils.ExtractMetadataFromFileStream(dto.Stream);
+            JsonDocument metadata = MetadataUtils.ExtractMetadataFromFileStream(dto.Stream, dto.FileExtension);
 
             return new SavedFileDataDB
             {


### PR DESCRIPTION
GetContentType() now uses a dictionary to retrieve its content type, this dictionary is also used by ExtractMetadataFromFileStream() to call the correct extractor method (for now only images and some office documents are implemented, unimplemented file types display trivial information for now via a default extractor).