### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/M-SAVA-INF/Managers/FileManager.cs
+++ b/M-SAVA-INF/Managers/FileManager.cs
@@ -73,6 +73,7 @@ namespace M_SAVA_INF.Managers
 
         public FileStream GetFileStream(string fileNameWithExtension)
         {
+            ValidateFileName(fileNameWithExtension);
             string fullPath = FileContentUtils.GetFullPath(fileNameWithExtension);
             if (!File.Exists(fullPath))
                 throw new FileNotFoundException($"File not found: {fullPath}");
@@ -154,6 +155,16 @@ namespace M_SAVA_INF.Managers
                 throw new UnauthorizedAccessException("User does not have access to this file's access group.");
             }
             return true;
+        }
+        private static void ValidateFileName(string fileNameWithExtension)
+        {
+            if (string.IsNullOrWhiteSpace(fileNameWithExtension) ||
+                fileNameWithExtension.Contains("..") ||
+                fileNameWithExtension.Contains("/") ||
+                fileNameWithExtension.Contains("\\"))
+            {
+                throw new ArgumentException("Invalid file name.");
+            }
         }
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Markinatorina/MSAVA/security/code-scanning/1](https://github.com/Markinatorina/MSAVA/security/code-scanning/1)

To fix this issue, we need to ensure that the user-supplied `fileNameWithExtension` cannot be used to traverse directories or access files outside of the intended storage directory. The best way is to validate the input before using it to construct a file path. This can be done by:

- Checking that `fileNameWithExtension` does not contain any path separators (`/` or `\`) or parent directory references (`..`).
- Optionally, only allowing file names that match a safe pattern (e.g., alphanumeric plus a dot and extension).
- This validation should be performed as early as possible, ideally in the `FileManager.GetFileStream(string fileNameWithExtension)` method, since this is the entry point for the tainted data.

**Implementation steps:**
- Add a private static method in `FileManager` to validate the file name.
- Call this validation method at the start of `GetFileStream(string fileNameWithExtension)` and throw an exception if the input is invalid.
- Optionally, also add this validation to other methods that accept `fileNameWithExtension` as input (e.g., `GetPhysicalFile`, `CheckFileAccessByPath`), but the main risk is in the file access methods.

**Required changes:**
- Edit `M-SAVA-INF/Managers/FileManager.cs`:
  - Add a private static method for validation.
  - Call this method at the start of `GetFileStream(string fileNameWithExtension)` (and optionally in other relevant methods).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
