### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/M-SAVA-INF/Managers/FileManager.cs
+++ b/M-SAVA-INF/Managers/FileManager.cs
@@ -14,12 +14,23 @@ namespace M_SAVA_INF.Managers
 {
     public class FileManager
     {
+        private static readonly string BaseDirectory = Path.GetFullPath("BaseDirectoryPath"); // Replace with actual base directory path
+
         private static bool IsSafeFileName(string fileName)
         {
             if (string.IsNullOrWhiteSpace(fileName))
                 return false;
-            if (fileName.Contains("..") || fileName.Contains("/") || fileName.Contains("\\"))
-                return false;
+
+            try
+            {
+                string fullPath = Path.GetFullPath(Path.Combine(BaseDirectory, fileName));
+                if (!fullPath.StartsWith(BaseDirectory, StringComparison.OrdinalIgnoreCase))
+                    return false;
+            }
+            catch
+            {
+                return false; // Invalid path
+            }
             return true;
         }
         public FileManager()

--- a/M-SAVA-INF/Managers/FileManager.cs
+++ b/M-SAVA-INF/Managers/FileManager.cs
@@ -14,6 +14,14 @@ namespace M_SAVA_INF.Managers
 {
     public class FileManager
     {
+        private static bool IsSafeFileName(string fileName)
+        {
+            if (string.IsNullOrWhiteSpace(fileName))
+                return false;
+            if (fileName.Contains("..") || fileName.Contains("/") || fileName.Contains("\\"))
+                return false;
+            return true;
+        }
         public FileManager()
         {
         }
@@ -73,6 +81,8 @@ namespace M_SAVA_INF.Managers
 
         public FileStream GetFileStream(string fileNameWithExtension)
         {
+            if (!IsSafeFileName(fileNameWithExtension))
+                throw new ArgumentException("Invalid file name: path traversal or separator detected.", nameof(fileNameWithExtension));
             ValidateFileName(fileNameWithExtension);
             string fullPath = FileContentUtils.GetFullPath(fileNameWithExtension);
             if (!File.Exists(fullPath))


### PR DESCRIPTION
Potential fix for [https://github.com/Markinatorina/MSAVA/security/code-scanning/1](https://github.com/Markinatorina/MSAVA/security/code-scanning/1)

To fix the problem, we need to ensure that the user-supplied `fileNameWithExtension` cannot be used to perform path traversal or access files outside the intended directory. The best way to do this is to validate that the input does not contain any path separators (`/`, `\`) or parent directory references (`..`). Additionally, we should ensure that the resolved path is within a designated safe directory. 

The fix should be applied in `FileManager.GetFileStream(string fileNameWithExtension)` in `M-SAVA-INF/Managers/FileManager.cs`. We will add a private method `IsSafeFileName` to perform the validation, and call it before constructing the path. If the input is invalid, we throw an exception.

**Required changes:**
- Add a private static method `IsSafeFileName` to check for path traversal and path separator characters.
- Call `IsSafeFileName` in `GetFileStream(string fileNameWithExtension)` before using the value.
- If the input is invalid, throw an `ArgumentException`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
